### PR TITLE
allow to set globalTimeout for rpc calls

### DIFF
--- a/lib/src/surrealdb.dart
+++ b/lib/src/surrealdb.dart
@@ -12,9 +12,10 @@ class SurrealDB {
   final _wsService = WSService();
 
   /// Connects to a local or remote database endpoint.
-  /// @param url - The url of the database endpoint to connect to.
-  void connect() {
-    _wsService.connect(url);
+  ///
+  /// [globalTimeout] - The [globalTimeout] for every RPC call. Defaults to 1 minute.
+  void connect([Duration globalTimeout = const Duration(minutes: 1)]) {
+    _wsService.connect(url, globalTimeout);
     _pinger = Pinger(const Duration(seconds: 30));
     _wsService.waitConnect.then((value) => _pinger?.start(() => ping()));
     if (token != null) authenticate(token!);

--- a/test/surrealdb_test.dart
+++ b/test/surrealdb_test.dart
@@ -3,8 +3,10 @@ import 'package:test/test.dart';
 import 'package:surrealdb/surrealdb.dart';
 
 void main() {
+  const _testUrl = 'ws://localhost:8000/rpc';
+
   test('should connect & disconnect', () async {
-    final client = SurrealDB('ws://localhost:8000/rpc');
+    final client = SurrealDB(_testUrl);
     client.connect();
     await client.wait();
     client.close();
@@ -12,7 +14,7 @@ void main() {
   });
 
   test('should connect, use, signin, close', () async {
-    final client = SurrealDB('ws://localhost:8000/rpc');
+    final client = SurrealDB(_testUrl);
     client.connect();
     await client.wait();
     await client.use('ns', 'db');
@@ -22,7 +24,7 @@ void main() {
   });
 
   test('should create', () async {
-    final client = SurrealDB('ws://localhost:8000/rpc');
+    final client = SurrealDB(_testUrl);
     client.connect();
     await client.wait();
     await client.use('ns', 'db');
@@ -48,7 +50,7 @@ void main() {
   });
 
   test('should delete,select', () async {
-    final client = SurrealDB('ws://localhost:8000/rpc');
+    final client = SurrealDB(_testUrl);
     client.connect();
     await client.wait();
     await client.use('ns', 'db');
@@ -86,7 +88,7 @@ void main() {
   });
 
   test('should select one', () async {
-    final client = SurrealDB('ws://localhost:8000/rpc');
+    final client = SurrealDB(_testUrl);
     client.connect();
     await client.wait();
     await client.use('ns', 'db');


### PR DESCRIPTION
I ran into some issues with the default timeout of 5 seconds 

`Future.delayed(timeout ?? const Duration(seconds: 5), () `

so I made it configurable at as a parameter for `client.connect();` which defaults to one minute.

I have also adapted the URL for the tests.

