### PR TITLE
Adding Middleware support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,61 @@ You can also authenticate with a token:
 await db.authenticate('your-auth-token');
 ```
 
-### Basic Queries
+### Middleware
 
+SurrealDB Flutter client supports middleware that allows you to intercept and modify requests before they are sent to the database. This is particularly useful for implementing token refresh functionality or adding logging.
+
+#### Adding Middleware
+
+You can add middleware using the `addMiddleware` method:
+
+```dart
+db.addMiddleware((method, params, next) async {
+  // Do something before the request
+  print('Before request: $method with params: $params');
+  
+  // Execute the request
+  final result = await next();
+  
+  // Do something after the request
+  print('After request: $method with result: $result');
+  
+  return result;
+});
+```
+
+Multiple middleware functions can be added, and they will be executed in the order they were added.
+
+#### Token Refresh Example
+
+Here's how you can implement token refresh using middleware:
+
+```dart
+db.addMiddleware((method, params, next) async {
+  try {
+    // Try to execute the request normally
+    return await next();
+  } catch (e) {
+    // If we get an authentication error
+    if (e.toString().contains('authentication invalid')) {
+      // Refresh the token (implement your token refresh logic)
+      final newToken = await refreshToken(); 
+      
+      // Re-authenticate with the new token
+      await db.authenticate(newToken);
+      
+      // Retry the original request
+      return await next();
+    }
+    // For other errors, just rethrow
+    rethrow;
+  }
+});
+```
+
+This middleware will catch authentication errors, refresh the token, and retry the original request automatically.
+
+### Basic Queries
 
 SurrealDB allows executing a variety of commands, including CRUD operations (Create, Read, Update, Delete) via queries. Here's how you can perform simple database operations.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: surrealdb
 description: SurrealDB client written in pure dart. Auto reconnect, Typed functions
-version: 1.0.2
+version: 1.1.0
 repository: https://github.com/duhanbalci/surrealdb_flutter
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   uuid: ^4.5.0


### PR DESCRIPTION
This pull request introduces middleware support for the SurrealDB Flutter client, allowing developers to intercept and modify requests before they are sent to the database. It also includes tests to ensure the middleware functions correctly.

Middleware support:

* [`lib/src/surrealdb.dart`](diffhunk://#diff-1523d8f9994890cc8105d4938cc86e24680e38c91c5eec63d44a98f56665b1acR7-R53): Added the `Middleware` typedef and the `addMiddleware` method to allow adding middleware functions that will be executed before each request. Middleware functions can modify requests, handle errors, and implement token refresh logic. [[1]](diffhunk://#diff-1523d8f9994890cc8105d4938cc86e24680e38c91c5eec63d44a98f56665b1acR7-R53) [[2]](diffhunk://#diff-1523d8f9994890cc8105d4938cc86e24680e38c91c5eec63d44a98f56665b1acR69-R71) [[3]](diffhunk://#diff-1523d8f9994890cc8105d4938cc86e24680e38c91c5eec63d44a98f56665b1acR180-R198)
* [`lib/src/ws.dart`](diffhunk://#diff-531b78521c52c14bd0457b6ff0df900068ff614091f85eb5062ea9f2054533aeR14-R19): Updated the `WSService` class to support middleware execution before making RPC calls. Added the `setMiddlewares` method to manage middleware functions and modified the `_rpc` method to build and execute the middleware chain. [[1]](diffhunk://#diff-531b78521c52c14bd0457b6ff0df900068ff614091f85eb5062ea9f2054533aeR14-R19) [[2]](diffhunk://#diff-531b78521c52c14bd0457b6ff0df900068ff614091f85eb5062ea9f2054533aeR33-R40) [[3]](diffhunk://#diff-531b78521c52c14bd0457b6ff0df900068ff614091f85eb5062ea9f2054533aeL90-R114) [[4]](diffhunk://#diff-531b78521c52c14bd0457b6ff0df900068ff614091f85eb5062ea9f2054533aeR148-R170)

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L100-R154): Updated the documentation to include information on how to add middleware, including an example of implementing token refresh using middleware.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R7): Bumped the version number to `1.1.0` to reflect the new middleware feature.

Testing:

* [`test/surrealdb_test.dart`](diffhunk://#diff-9abacbe5bc55d84c3b4206e99c6351a56df70d28757f8e1ba3b157cccc957b79R249-R416): Added a new test group for middleware tests, including tests for single and multiple middleware functions, modifying results, handling errors, and demonstrating a token refresh scenario.